### PR TITLE
81 Tiles and ToggleTrafficLights

### DIFF
--- a/Areas/FakeGameAreaManager.cs
+++ b/Areas/FakeGameAreaManager.cs
@@ -58,7 +58,17 @@ namespace EightyOne.Areas
                         BindingFlags.Static | BindingFlags.Public);
                 }
             }
+            SimulationManager.instance.AddAction(() =>
+            {
+                FakeNetManager.DontUpdateNodeFlags = true;
+                UnityEngine.Debug.Log($"81 Tiles - DontUpdateNodeFlags enabled");
+            });
             SimulationManager.instance.AddAction(FakeGameAreaManagerInit.UpdateData);
+            SimulationManager.instance.AddAction(() =>
+            {
+                FakeNetManager.DontUpdateNodeFlags = false;
+                UnityEngine.Debug.Log($"81 Tiles - DontUpdateNodeFlags disabled");
+            });
         }
 
         [RedirectMethod]

--- a/Areas/FakeGameAreaManager.cs
+++ b/Areas/FakeGameAreaManager.cs
@@ -61,13 +61,13 @@ namespace EightyOne.Areas
             SimulationManager.instance.AddAction(() =>
             {
                 FakeNetManager.DontUpdateNodeFlags = true;
-                UnityEngine.Debug.Log($"81 Tiles - DontUpdateNodeFlags enabled");
+                Debug.Log($"81 Tiles - DontUpdateNodeFlags enabled");
             });
             SimulationManager.instance.AddAction(FakeGameAreaManagerInit.UpdateData);
             SimulationManager.instance.AddAction(() =>
             {
                 FakeNetManager.DontUpdateNodeFlags = false;
-                UnityEngine.Debug.Log($"81 Tiles - DontUpdateNodeFlags disabled");
+                Debug.Log($"81 Tiles - DontUpdateNodeFlags disabled");
             });
         }
 

--- a/Areas/FakeNetManager.cs
+++ b/Areas/FakeNetManager.cs
@@ -67,5 +67,22 @@ namespace EightyOne.Areas
             }
             return 0;
         }
+
+        public static bool DontUpdateNodeFlags = false;
+        [RedirectMethod]
+        public void UpdateNodeFlags(ushort node)
+        {
+            UnityEngine.Debug.Log($"81 Tiles - in UpdateNodeFlags with DontUpdateNodeFlags={DontUpdateNodeFlags}");
+            if (!DontUpdateNodeFlags)
+            {
+                if (NetManager.instance.m_nodes.m_buffer[(int)node].m_flags == NetNode.Flags.None)
+                    return;
+                NetInfo info = NetManager.instance.m_nodes.m_buffer[(int)node].Info;
+                if (info == null)
+                    return;
+                info.m_netAI.UpdateNodeFlags(node, ref NetManager.instance.m_nodes.m_buffer[(int)node]);
+
+            }
+        }
     }
 }

--- a/Areas/FakeNetManager.cs
+++ b/Areas/FakeNetManager.cs
@@ -68,11 +68,11 @@ namespace EightyOne.Areas
             return 0;
         }
 
-        public static bool DontUpdateNodeFlags = false;
+                public static bool DontUpdateNodeFlags = false;
         [RedirectMethod]
         public void UpdateNodeFlags(ushort node)
         {
-            UnityEngine.Debug.Log($"81 Tiles - in UpdateNodeFlags with DontUpdateNodeFlags={DontUpdateNodeFlags}");
+            //Debug.Log($"81 Tiles - in UpdateNodeFlags with DontUpdateNodeFlags={DontUpdateNodeFlags}");
             if (!DontUpdateNodeFlags)
             {
                 if (NetManager.instance.m_nodes.m_buffer[(int)node].m_flags == NetNode.Flags.None)


### PR DESCRIPTION
Hi

> @Craxy I can call some method of your mod after everything's loaded. Just tell me which.

I don't like that manual approach for each mod -- a hook for TTL, another one for Traffic Manager, maybe another one for Traffic++, etc..
So I dug a bit more -- and came to a quite simple solution: just disable the update of nodes while the tiles are initialized.

I'm redirecting the NetManager.UpdateNodeFlags method and call the original content only when DontUpdateNodeFlags is false. The bool gets set before FakeGameAreaManagerInit.UpdateData and again unset after FakeGameAreaManagerInit.UpdateData. Works quite fine -- at least in a very basic test (just some streets outside the default C:S tiles); it should be tested in bigger city too. But one possible issue: UpdateNodeFlags seems to get called async -- and because of that DontUpdateNodeFlags might get unset to early. I'm not quite sure if that's really the case, but at least in the log for my simple test there were two calls to UpdateNodeFlags after DontUpdateNodeFlags was unset. But I'm not sure if that's because it gets unset to early or because UpdateNodeFlags gets called from somewhere else. Maybe there is even a better location to disable and reenable the usage of UpdateNodeFlags -- the implementation is more of an idea how it can be done than really to say that's the correct way and position to do this -- I would have to dig more into the code to see that (and I'm to lazy for that :D).

About the commits: works in my simple test -- but don't know about bigger cities. So should probably not be directly pulled into an update of 81 tiles mod, but tested first.
