### PR TITLE
Catch exceptions when trying to alter edge fog effects

### DIFF
--- a/LoadingExtension.cs
+++ b/LoadingExtension.cs
@@ -25,9 +25,16 @@ namespace EightyOne
                 return;
             }
             Detours.Deploy();
-            SimulationManager.instance.AddAction(() => Object.FindObjectOfType<RenderProperties>().m_edgeFogDistance = 2800f);
-            SimulationManager.instance.AddAction(() => Object.FindObjectOfType<FogEffect>().m_edgeFogDistance = 2800f);
-            SimulationManager.instance.AddAction(() => Object.FindObjectOfType<FogProperties>().m_EdgeFogDistance = 2800f);
+            try
+            {
+                SimulationManager.instance.AddAction(() => Object.FindObjectOfType<RenderProperties>().m_edgeFogDistance = 2800f);
+                SimulationManager.instance.AddAction(() => Object.FindObjectOfType<FogEffect>().m_edgeFogDistance = 2800f);
+                SimulationManager.instance.AddAction(() => Object.FindObjectOfType<FogProperties>().m_EdgeFogDistance = 2800f);
+            }
+            catch
+            {
+                UIView.library.ShowModal<ExceptionPanel>("ExceptionPanel").SetMessage("81 Tiles self-check: Mod conflict", "Another mod has altered edge fog effects; 81 Tiles was unable to reduce the edge fog.", false);
+            }
             if (Util.IsModActive(Mod.ALL_TILES_START_MOD))
             {
                 UIView.library.ShowModal<ExceptionPanel>("ExceptionPanel").SetMessage(


### PR DESCRIPTION
An as-yet unidentified mod (too tired to do the digging due to some RL stuff) is causing CTD when 81 Tiles tries to update the edge fog distance in `LoadingExtension.cs`.

This PR wraps the relevant code in `try..catch` in an attempt to prevent CTD, and will notifiy users if successful.

An alternate (better?) approach might be to add new mod option to toggle whether fog distance is changed.

```diff
========== OUTPUTING STACK TRACE ==================

  ERROR: SymGetSymFromAddr64, GetLastError: 'Attempt to access invalid address.' (Address: 00007FF6905EA471)
0x00007FF6905EA471 (Cities) 
  ERROR: SymGetSymFromAddr64, GetLastError: 'Attempt to access invalid address.' (Address: 00007FF6905F48F1)
0x00007FF6905F48F1 (Cities) 
  ERROR: SymGetSymFromAddr64, GetLastError: 'Attempt to access invalid address.' (Address: 00007FF6905EB33A)
0x00007FF6905EB33A (Cities) 
  ERROR: SymGetSymFromAddr64, GetLastError: 'Attempt to access invalid address.' (Address: 00007FF6905EFAE8)
0x00007FF6905EFAE8 (Cities) 
  ERROR: SymGetSymFromAddr64, GetLastError: 'Attempt to access invalid address.' (Address: 00007FF6907C4207)
0x00007FF6907C4207 (Cities) 
0x000000000845283C (Mono JIT Code) (wrapper managed-to-native) UnityEngine.Object:FindObjectsOfType (System.Type)
0x000000000845275A (Mono JIT Code) UnityEngine.Object:FindObjectOfType (System.Type)
0x0000000008519AD9 (Mono JIT Code) UnityEngine.Object:FindObjectOfType<object> ()
- 0x000000000F86140F (Mono JIT Code) EightyOne.LoadingExtension/<>c:<OnLevelLoaded>b__1_1 ()
0x000000013B40A54A (Mono JIT Code) AsyncAction:Execute ()
0x0000000028491AEB (Mono JIT Code) SimulationManager:SimulationStep ()
0x00000000283DCA9B (Mono JIT Code) SimulationManager:SimulationThread ()
0x000000000619DE8B (Mono JIT Code) (wrapper runtime-invoke) object:runtime_invoke_void__this__ (object,intptr,intptr,intptr)
0x00007FF902775CDF (mono) mono_set_defaults
0x00007FF9026C8499 (mono) mono_runtime_invoke
0x00007FF9026F38D7 (mono) mono_thread_interruption_request_flag
0x00007FF9027A8955 (mono) unity_mono_reflection_method_get_method
0x00007FF976177BD4 (KERNEL32) BaseThreadInitThunk
0x00007FF97710CE51 (ntdll) RtlUserThreadStart

========== END OF STACKTRACE ===========

**** Crash! ****
```